### PR TITLE
unescape generic unicode character

### DIFF
--- a/Src/to-json.groovy
+++ b/Src/to-json.groovy
@@ -1,6 +1,8 @@
 import groovy.json.JsonOutput;
+import groovy.json.StringEscapeUtils;
 
 def invoke(msg) {
-    msg.put("user", JsonOutput.toJson(msg.get("user")));
+    def jsonString = StringEscapeUtils.unescapeJava(JsonOutput.toJson(msg.get("user")))
+    msg.put("user", jsonString);
     return true;
 }


### PR DESCRIPTION
Unescape optional escape Unicode character for human readable

https://tools.ietf.org/html/rfc7159#section-7

>  except for the characters that must be escaped:
>    quotation mark, reverse solidus, and the control characters (U+0000 through U+001F).